### PR TITLE
[NEW FEATURE] Weights by map

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,10 @@
 {
     "spt_realism_ammo_compat": false,
 
+    "map_weights_enabled": true,
+
+    "debug_mode": false,
+
     "spawnpoint_item_type_blacklist":[
         "5c164d2286f774194c5e69fa",
         "5c99f98d86f7745c314214b3",

--- a/config/configs/weights.json
+++ b/config/configs/weights.json
@@ -5,54 +5,132 @@
     "CATEGORIES":{
 
         "GRENADES_UGL_FLARES":{
-            "low": 1, 
-            "medium": 0.6,
-            "high": 0.2
+            "low": {
+                "GLOBAL": 1
+            }, 
+            "medium": {
+                "GLOBAL": 0.6
+            }, 
+            "high": {
+                "GLOBAL": 0.2
+            }
         },
 
         "SHOTGUNS":{
-            "crap": 1,
-            "pen_medium": 0.8,
-            "flesh_medium": 0.6,
-            "flesh_high": 0.3,
-            "pen_high": 0.3,
-            "util": 0.1
+            "crap": {
+                "GLOBAL": 1
+            },
+            "pen_medium": {
+                "GLOBAL": 0.8
+            },
+            "flesh_medium": {
+                "GLOBAL": 0.6
+            },
+            "flesh_high": {
+                "GLOBAL": 0.3
+            },
+            "pen_high": {
+                "GLOBAL": 0.3
+            },
+            "util": {
+                "GLOBAL": 0.1
+            }
         },
 
         "GENERAL":{
-            "crap": 1,
-            "flesh_medium": 0.8,
-            "flesh_high": 0.6,
-            "pen_medium": 0.5,
-            "pen_high": 0.2,
-            "pen_veryhigh": 0.1
+            "crap": {
+                "GLOBAL": 1
+            },
+            "flesh_medium": {
+                "GLOBAL": 0.8
+            },
+            "flesh_high": {
+                "GLOBAL": 0.6
+            },
+            "pen_medium": {
+                "GLOBAL": 0.5
+            },
+            "pen_high": {
+                "GLOBAL": 0.2
+            },
+            "pen_veryhigh": {
+                "GLOBAL": 0.1
+            }
         },
 
         "CALIBERS":{
-            "GRENADES": 0.4,
-            "UGL": 0.1,
-            "FLARES": 0.2,
-            "7.62x25": 0.7,
-            "9x18": 0.7,
-            "9x19": 1,
-            "9x21": 1,
-            ".357": 0.8,
-            ".45": 1,
-            "4.6x30": 1,
-            "5.7x28": 1,
-            "5.45x39": 1,
-            "5.56x45": 1,
-            ".300blk": 1,
-            "7.62x39": 1,
-            "7.62x51": 1,
-            "7.62x54R": 0.8,
-            ".338lapua": 0.3,
-            "9x39": 1,
-            ".366tkm": 1,
-            "12.7x55": 0.6,
-            "12x70": 1,
-            "20x70": 0.7,
-            "23x75": 1
+            "GRENADES": {
+                "GLOBAL": 0.4
+            },
+            "UGL": {
+                "GLOBAL": 0.1
+            },
+            "FLARES": {
+                "GLOBAL": 0.2
+            },
+            "7.62x25": {
+                "GLOBAL": 0.7
+            },
+            "9x18": {
+                "GLOBAL": 0.7
+            },
+            "9x19": {
+                "GLOBAL": 1
+            },
+            "9x21": {
+                "GLOBAL": 1
+            },
+            ".357": {
+                "GLOBAL": 0.8
+            },
+            ".45": {
+                "GLOBAL": 1
+            },
+            "4.6x30": {
+                "GLOBAL": 1
+            },
+            "5.7x28": {
+                "GLOBAL": 1
+            },
+            "5.45x39": {
+                "GLOBAL": 1
+            },
+            "5.56x45": {
+                "GLOBAL": 1
+            },
+            ".300blk": {
+                "GLOBAL": 1
+            },
+            "7.62x39": {
+                "GLOBAL": 1
+            },
+            "7.62x51": {
+                "GLOBAL": 1
+            },
+            "7.62x54R": {
+                "GLOBAL": 0.8
+            },
+            ".338lapua": {
+                "GLOBAL": 0.3
+            },
+            "9x39": {
+                "GLOBAL": 1
+            },
+            ".366tkm": {
+                "GLOBAL": 1
+            },
+            "12.7x55": {
+                "GLOBAL": 0.6
+            },
+            "12x70": {
+                "GLOBAL": 1
+            },
+            "20x70": {
+                "GLOBAL": 0.7
+            },
+            "23x75": {
+                "GLOBAL": 1
+            }
         }
     }
 }

--- a/config/realism configs/weights_realism.json
+++ b/config/realism configs/weights_realism.json
@@ -5,54 +5,132 @@
     "CATEGORIES":{
 
         "GRENADES_UGL_FLARES":{
-            "low": 1,
-            "medium": 0.6,
-            "high": 0.2
+            "low": {
+                "GLOBAL": 1
+            },
+            "medium": {
+                "GLOBAL": 0.6
+            },
+            "high": {
+                "GLOBAL": 0.2
+            }
         },
 
         "SHOTGUNS":{
-            "crap": 1,
-            "pen_medium": 0.8,
-            "flesh_medium": 0.6,
-            "flesh_high": 0.3,
-            "pen_high": 0.3,
-            "util": 0.1
+            "crap": {
+                "GLOBAL": 1
+            },
+            "pen_medium": {
+                "GLOBAL": 0.8
+            },
+            "flesh_medium": {
+                "GLOBAL": 0.6
+            },
+            "flesh_high": {
+                "GLOBAL": 0.3
+            },
+            "pen_high": {
+                "GLOBAL": 0.3
+            },
+            "util": {
+                "GLOBAL": 0.1
+            }
         },
 
         "GENERAL":{
-            "crap": 1,
-            "flesh_medium": 0.8,
-            "flesh_high": 0.6,
-            "pen_medium": 0.5,
-            "pen_high": 0.2,
-            "pen_veryhigh": 0.1
+            "crap": {
+                "GLOBAL": 1
+            },
+            "flesh_medium": {
+                "GLOBAL": 0.8
+            },
+            "flesh_high": {
+                "GLOBAL": 0.6
+            },
+            "pen_medium": {
+                "GLOBAL": 0.5
+            },
+            "pen_high": {
+                "GLOBAL": 0.2
+            },
+            "pen_veryhigh": {
+                "GLOBAL": 0.1
+            }
         },
 
         "CALIBERS":{
-            "GRENADES": 0.4,
-            "UGL": 0.1,
-            "FLARES": 0.2,
-            "7.62x25": 0.7,
-            "9x18": 0.7,
-            "9x19": 1,
-            "9x21": 1,
-            ".357": 0.8,
-            ".45": 1,
-            "4.6x30": 1,
-            "5.7x28": 1,
-            "5.45x39": 1,
-            "5.56x45": 1,
-            ".300blk": 1,
-            "7.62x39": 1,
-            "7.62x51": 1,
-            "7.62x54R": 0.8,
-            ".338lapua": 0.3,
-            "9x39": 1,
-            ".366tkm": 1,
-            "12.7x55": 0.6,
-            "12x70": 1,
-            "20x70": 0.7,
-            "23x75": 1
+            "GRENADES": {
+                "GLOBAL": 0.4
+            },
+            "UGL": {
+                "GLOBAL": 0.1
+            },
+            "FLARES": {
+                "GLOBAL": 0.2
+            },
+            "7.62x25": {
+                "GLOBAL": 0.7
+            },
+            "9x18": {
+                "GLOBAL": 0.7
+            },
+            "9x19": {
+                "GLOBAL": 1
+            },
+            "9x21": {
+                "GLOBAL": 1
+            },
+            ".357": {
+                "GLOBAL": 0.8
+            },
+            ".45": {
+                "GLOBAL": 1
+            },
+            "4.6x30": {
+                "GLOBAL": 1
+            },
+            "5.7x28": {
+                "GLOBAL": 1
+            },
+            "5.45x39": {
+                "GLOBAL": 1
+            },
+            "5.56x45": {
+                "GLOBAL": 1
+            },
+            ".300blk": {
+                "GLOBAL": 1
+            },
+            "7.62x39": {
+                "GLOBAL": 1
+            },
+            "7.62x51": {
+                "GLOBAL": 1
+            },
+            "7.62x54R": {
+                "GLOBAL": 0.8
+            },
+            ".338lapua": {
+                "GLOBAL": 0.3
+            },
+            "9x39": {
+                "GLOBAL": 1
+            },
+            ".366tkm": {
+                "GLOBAL": 1
+            },
+            "12.7x55": {
+                "GLOBAL": 0.6
+            },
+            "12x70": {
+                "GLOBAL": 1
+            },
+            "20x70": {
+                "GLOBAL": 0.7
+            },
+            "23x75": {
+                "GLOBAL": 1
+            }
         }
     }
 }


### PR DESCRIPTION
### [NEW FEATURE] Weights by map

This PR enables weights by map.

`map_weights_enabled` must be set to `true` (true by default). Then, user may set up different weights by caliber and by tier. If a value is not defined for a map, BOOBS will rely on GLOBAL value.

For example, if I want `7.62x25` to be more common on Reserve:

```
        "CALIBERS":{
           [...]
            "UGL": {
                "GLOBAL": 0.1
            },
            "FLARES": {
                "GLOBAL": 0.2
            },
            "7.62x25": {
                "GLOBAL": 0.7,
                "rezervbase": 0.85
            },
           [...]
```
In this case, the weight was increased from 0.7 to 0.85 **only on reserve.**

The map list ATM is:
Customs: "bigmap"
Factory - Day: "factory4_day"
Factory - Night: "factory4_night"
Interchange: "interchange"
Labs: "laboratory"
Lighthouse: "lighthouse"
Reserve: "rezervbase"
Shoreline: "shoreline"
Streets of Tarkov: "tarkovstreets"
Woods: "woods"
Ground Zero: "sandbox"